### PR TITLE
usage in china

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ WeChat PC will be started on your Linux desktop by running the following one-lin
 curl -sL https://raw.githubusercontent.com/huan/docker-wechat/master/dochat.sh | bash
 ```
 
+If you’re in China, try the following one-line command if the above one-line command does not work well:
+```sh
+curl -sL https://gitee.com/mirrors/dochat/raw/main/dochat.sh | bash
+```
+
 Just copy/paste the above one-line command to your terminal and press Enter. Then the WeChat PC should appear in your XWindows desktop shortly.
 
 ![DoChat Term Command](https://huan.github.io/docker-wechat/images/term-dochat.png)


### PR DESCRIPTION
In China, we often failed to connect to `raw.githubusercontent.com`.
`https://gitee.com/mirrors/dochat` synchronizes everyday.
Please feel free to decline this pull request.