### PR TITLE
update shellcheck action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: zbeekman/ShellCheck-Linter-Action@v1.0.1
+      - uses: reviewdog/action-shellcheck@v1
       - name: Install Dependencies
         run: make install
       # - name: Build


### PR DESCRIPTION
The shellcheck action fails with the following error:

```
/usr/bin/docker run --name bcf098eb77799c8974c7e875[3](https://github.com/huan/docker-wechat/runs/6048258945?check_suite_focus=true#step:4:3)759b1db9b166_0ebcbb --label 2bcf09 --workdir /github/workspace --rm -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_RUN_ATTEMPT -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_REF_NAME -e GITHUB_REF_PROTECTED -e GITHUB_REF_TYPE -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e GITHUB_STEP_SUMMARY -e RUNNER_OS -e RUNNER_ARCH -e RUNNER_NAME -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/docker-wechat/docker-wechat":"/github/workspace" 2bcf09:8eb77799c897[4](https://github.com/huan/docker-wechat/runs/6048258945?check_suite_focus=true#step:4:4)c7e87[5](https://github.com/huan/docker-wechat/runs/6048258945?check_suite_focus=true#step:4:5)3759b1db9b1[6](https://github.com/huan/docker-wechat/runs/6048258945?check_suite_focus=true#step:4:6)6
fatal: unsafe repository ('/github/workspace' is owned by someone else)
ShellCheck - shell script analysis tool
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
version: 0.[8](https://github.com/huan/docker-wechat/runs/6048258945?check_suite_focus=true#step:4:8).0
license: GNU General Public License, version 3
website: https://www.shellcheck.net/
Configuring git...
Enumerating files tracked by git...
```

https://github.com/huan/docker-wechat/runs/6048258945?check_suite_focus=true

[ShellCheck-Linter-Action](https://github.com/zbeekman/ShellCheck-Linter-Action) is deprecated and [reviewdog/action-shellcheck](https://github.com/reviewdog/action-shellcheck) is recommended.