### PR TITLE
挂载持久化卷时，可以提前创建好对应目录，这样可以不依赖docker的自动创建目录的特性，避免权限问题

### DIFF
--- a/dochat.sh
+++ b/dochat.sh
@@ -89,6 +89,10 @@ function main () {
   # Issue #111 - https://github.com/huan/docker-wechat/issues/111
   rm -f "$HOME/DoChat/Applcation Data/Tencent/WeChat/All Users/config/configEx.ini"
 
+  # Issue #165 - https://github.com/huan/docker-wechat/issues/165#issuecomment-1643063633
+  mkdir $HOME/DoChat/"WeChat Files"/ -p
+  mkdir $HOME/DoChat/"Applcation Data"/
+
   #
   # --privileged: enable sound (/dev/snd/)
   # --ipc=host:   enable MIT_SHM (XWindows)
@@ -100,7 +104,7 @@ function main () {
     -i \
     \
     -v "$HOME/DoChat/WeChat Files/":'/home/user/WeChat Files/' \
-    -v "$HOME/DoChat/Applcation Data":'/home/user/.wine/drive_c/users/user/Application Data/' \
+    -v "$HOME/DoChat/Applcation Data/":'/home/user/.wine/drive_c/users/user/Application Data/' \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     \
     -e DISPLAY \

--- a/dochat.sh
+++ b/dochat.sh
@@ -98,8 +98,9 @@ function main () {
   rm -f "$HOME/DoChat/Applcation Data/Tencent/WeChat/All Users/config/configEx.ini"
 
   # Issue #165 - https://github.com/huan/docker-wechat/issues/165#issuecomment-1643063633
-  mkdir $HOME/DoChat/"WeChat Files"/ -p
-  mkdir $HOME/DoChat/"Applcation Data"/
+  HOST_DIR_HOME_DOCHAT_WECHAT_FILES = "$HOME/DoChat/WeChat Files/"
+  mkdir "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES" -p
+  mkdir "$HOME"/DoChat/"Applcation Data"/
 
   #
   # --privileged: enable sound (/dev/snd/)

--- a/dochat.sh
+++ b/dochat.sh
@@ -98,8 +98,8 @@ function main () {
   rm -f "$HOME/DoChat/Applcation Data/Tencent/WeChat/All Users/config/configEx.ini"
 
   # Issue #165 - https://github.com/huan/docker-wechat/issues/165#issuecomment-1643063633
-  HOST_DIR_HOME_DOCHAT_WECHAT_FILES = "$HOME/DoChat/WeChat Files/"
-  HOST_DIR_HOME_DOCHAT_APPLICATION_DATA = "$HOME/DoChat/Applcation Data/"
+  HOST_DIR_HOME_DOCHAT_WECHAT_FILES="$HOME/DoChat/WeChat Files/"
+  HOST_DIR_HOME_DOCHAT_APPLICATION_DATA="$HOME/DoChat/Applcation Data/"
   mkdir "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES" -p
   mkdir "$HOST_DIR_HOME_DOCHAT_APPLICATION_DATA" -p
 

--- a/dochat.sh
+++ b/dochat.sh
@@ -99,8 +99,9 @@ function main () {
 
   # Issue #165 - https://github.com/huan/docker-wechat/issues/165#issuecomment-1643063633
   HOST_DIR_HOME_DOCHAT_WECHAT_FILES = "$HOME/DoChat/WeChat Files/"
+  HOST_DIR_HOME_DOCHAT_APPLICATION_DATA = "$HOME/DoChat/Applcation Data/"
   mkdir "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES" -p
-  mkdir "$HOME"/DoChat/"Applcation Data"/
+  mkdir "$HOST_DIR_HOME_DOCHAT_APPLICATION_DATA" -p
 
   #
   # --privileged: enable sound (/dev/snd/)
@@ -112,8 +113,8 @@ function main () {
     --rm \
     -i \
     \
-    -v "$HOME/DoChat/WeChat Files/":'/home/user/WeChat Files/' \
-    -v "$HOME/DoChat/Applcation Data/":'/home/user/.wine/drive_c/users/user/Application Data/' \
+    -v "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES":'/home/user/WeChat Files/' \
+    -v "$HOST_DIR_HOME_DOCHAT_APPLICATION_DATA":'/home/user/.wine/drive_c/users/user/Application Data/' \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
     \
     -e DISPLAY \


### PR DESCRIPTION
[#165 ](https://github.com/huan/docker-wechat/issues/165#issuecomment-1643063633)