### PR TITLE
Disallow root script run

### DIFF
--- a/dochat.sh
+++ b/dochat.sh
@@ -18,6 +18,12 @@ set -eo pipefail
 #   2020-04-01: 2.7.1.85
 #   2020-08-24: 3.3.0.115 (not working yet)
 #   2020-09-01: 3.3.0.115 (alpha testing)
+
+if [ "$EUID" -eq 0 ] && [ "${ALLOWROOT:-0}" -ne "1" ]
+then echo "Please do not run this script as root."
+  exit 1
+fi
+
 DEFAULT_WECHAT_VERSION=3.3.0.115
 
 #
@@ -79,7 +85,7 @@ function main () {
   for DEVICE in /dev/video* /dev/snd; do
     DEVICE_ARG+=('--device' "$DEVICE")
   done
-  if [[ $(lshw -C display | grep vendor) =~ NVIDIA ]]; then
+  if [[ $(lshw -C display 2> /dev/null | grep vendor) =~ NVIDIA ]]; then
     DEVICE_ARG+=('--gpus' 'all' '--env' 'NVIDIA_DRIVER_CAPABILITIES=all')
   fi
 

--- a/dochat.sh
+++ b/dochat.sh
@@ -22,7 +22,7 @@ set -eo pipefail
 if [ "$EUID" -eq 0 ] && [ "${ALLOWROOT:-0}" -ne "1" ]
 then
   echo "Please do not run this script as root."
-  echo "see https://github.com/huan/docker-wechat/pull/209
+  echo "see https://github.com/huan/docker-wechat/pull/209"
   exit 1
 fi
 

--- a/dochat.sh
+++ b/dochat.sh
@@ -20,7 +20,9 @@ set -eo pipefail
 #   2020-09-01: 3.3.0.115 (alpha testing)
 
 if [ "$EUID" -eq 0 ] && [ "${ALLOWROOT:-0}" -ne "1" ]
-then echo "Please do not run this script as root."
+then
+  echo "Please do not run this script as root."
+  echo "see https://github.com/huan/docker-wechat/pull/209
   exit 1
 fi
 

--- a/dochat.sh
+++ b/dochat.sh
@@ -129,7 +129,12 @@ function main () {
     \
     "$DOCHAT_IMAGE_VERSION"
 
-    echo
+    #
+    # Do not put any command between
+    # the above "docker run" and
+    # the below "echo"
+    # because we need to output error code $?
+    #
     echo "📦 DoChat Exited with code [$?]"
     echo
     echo '🐞 Bug Report: https://github.com/huan/docker-wechat/issues'


### PR DESCRIPTION
I added a check to stop the script if the user is root. Also, I hid an environment variable `ALLOWROOT` which if set to 1 will allow the script to run if the user wants to run it as root for whatever reason. 

This would avoid numerous issues with `~/DoChat` becoming owned by root causing permission denided issues (such as in https://github.com/huan/docker-wechat/issues/165 and  https://github.com/huan/docker-wechat/issues/178). 

Also, I got rid of the warning message of `lshw -C display` which, if not run with sudo, confusingly prints out `WARNING: you should run this program as super-user.`, which can mislead people (including me) to run the script with sudo