### PR TITLE
add option to mount user's home dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ curl -sL https://raw.githubusercontent.com/huan/docker-wechat/master/dochat.sh \
   | DOCHAT_WECHAT_VERSION=3.3.0.115 bash
 ```
 
+### `DOCHAT_MOUNT_HOME`
+
+Mount user's home directory to container path `/home/user/home`, which is accessable from the Choose File Dialog -> My Documents -> home.
+
+```sh
+curl -sL https://raw.githubusercontent.com/huan/docker-wechat/master/dochat.sh \
+  | DOCHAT_MOUNT_HOME=true bash
+```
+
+Or in case you have downloaded `dochat.sh`:
+
+```sh
+DOCHAT_MOUNT_HOME=true ./dochat.sh
+```
+
 ## For Hackers
 
 If you want to control everything by yourself, for example, open multiple WeChat PC client on your desktop; then, you might want to inspect the [dochat.sh](https://github.com/huan/docker-wechat/blob/master/dochat.sh) in our repository and try the following docker command:

--- a/dochat.sh
+++ b/dochat.sh
@@ -94,6 +94,8 @@ function main () {
   echo '🚀 Starting DoChat /dɑɑˈtʃæt/ ...'
   echo
 
+  VOLUME_ARG=()
+
   # Issue #111 - https://github.com/huan/docker-wechat/issues/111
   rm -f "$HOME/DoChat/Applcation Data/Tencent/WeChat/All Users/config/configEx.ini"
 
@@ -102,6 +104,14 @@ function main () {
   HOST_DIR_HOME_DOCHAT_APPLICATION_DATA="$HOME/DoChat/Applcation Data/"
   mkdir "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES" -p
   mkdir "$HOST_DIR_HOME_DOCHAT_APPLICATION_DATA" -p
+
+  VOLUME_ARG+=('-v' "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES":'/home/user/WeChat Files/')
+  VOLUME_ARG+=('-v' "$HOST_DIR_HOME_DOCHAT_APPLICATION_DATA":'/home/user/.wine/drive_c/users/user/Application Data/')
+  VOLUME_ARG+=('-v' '/tmp/.X11-unix:/tmp/.X11-unix')
+  VOLUME_ARG+=('-v' "/run/user/$(id -u)/pulse":'/run/pulse')
+  if [ -n "$DOCHAT_MOUNT_HOME" ]; then
+    VOLUME_ARG+=('-v' "$HOME":'/home/user/home')
+  fi
 
   #
   # --privileged: enable sound (/dev/snd/)
@@ -113,10 +123,7 @@ function main () {
     --rm \
     -i \
     \
-    -v "$HOST_DIR_HOME_DOCHAT_WECHAT_FILES":'/home/user/WeChat Files/' \
-    -v "$HOST_DIR_HOME_DOCHAT_APPLICATION_DATA":'/home/user/.wine/drive_c/users/user/Application Data/' \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    -v "/run/user/$(id -u)/pulse":"/run/pulse" \
+    "${VOLUME_ARG[@]}" \
     \
     -e DISPLAY \
     -e DOCHAT_DEBUG \


### PR DESCRIPTION
If the DOCHAT_MOUNT_HOME environment variable is defined, mount the user's home directory to /home/user/home in the container. User can access files in his/her home from Open File Dialog -> My Documents -> home.